### PR TITLE
Work around BlockLayoutCell regression by using UI5 1.63

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -6,7 +6,7 @@
 	<title>UI5Lab Browser</title>
 
 	<script id="sap-ui-bootstrap"
-		src="https://openui5nightly.hana.ondemand.com/resources/sap-ui-core.js"
+		src="https://openui5.hana.ondemand.com/1.63.0/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_belize"
 		data-sap-ui-resourceroots='{
 			"ui5lab.browser": "./",


### PR DESCRIPTION
Right now the browser fails to display any libraries, due to a regression in BlockLayoutCell (internal ticket opened).
Let's temporarily use the still working version 1.63.

Anyway, is using the openui5nightly a conscious (and good) decision?